### PR TITLE
Feature: Support user input label

### DIFF
--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cashapp/AccessibilitySnapshot.git",
       "state" : {
-        "revision" : "482db2fd4251cce237d8106073a53ad5289ce739",
-        "version" : "0.6.0"
+        "revision" : "ef2cf6015ad00c791fe3ff60f836b1fcc50f970c",
+        "version" : "0.7.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/playbook-ui/playbook-ios.git",
       "state" : {
-        "revision" : "0e7c312abdb4f7afeaf24369bab114cf475f573c",
-        "version" : "0.3.5"
+        "revision" : "da86a1a533e7ab5b1203908dfbb33aa38b782421",
+        "version" : "0.4.1"
       }
     },
     {

--- a/Example/README.md
+++ b/Example/README.md
@@ -1,5 +1,5 @@
 # How to Run
 
 1. Open `Example.xcodeproj` via Xcode
-1. Run (⌘+R) `Sample` scheme
-1. Run test (⌘+U) `Sample` sceme to generate snapshot images
+1. Run (⌘+R) `SampleApp` scheme
+1. Run test (⌘+U) `SampleApp` sceme to generate snapshot images

--- a/Example/SampleApp/AccessibilityExamples/RepresentableExample_iOS.swift
+++ b/Example/SampleApp/AccessibilityExamples/RepresentableExample_iOS.swift
@@ -12,10 +12,11 @@ import UIKit
 public final class RepresentableUIView: UIView {
     public var color: UIColor
 
-    public init(_ color: UIColor) {
+    public init(_ color: UIColor, accessibilityUserInputLabels: [String]) {
         self.color = color
         super.init(frame: .zero)
         self.isAccessibilityElement = true
+        self.accessibilityUserInputLabels = accessibilityUserInputLabels
         layer.backgroundColor = color.cgColor
         layer.cornerRadius = defaultCornerRadius
         layer.borderColor = UIColor.black.cgColor
@@ -29,7 +30,7 @@ public final class RepresentableUIView: UIView {
 
 public struct RepresentableView: UIViewRepresentable {
     public func makeUIView(context: UIViewRepresentableContext<RepresentableView>) -> RepresentableUIView {
-        return RepresentableUIView(.red)
+        return RepresentableUIView(.red, accessibilityUserInputLabels: ["Red", "Rectangular"])
     }
 
     public func updateUIView(_ nsView: RepresentableUIView, context: UIViewRepresentableContext<RepresentableView>) {
@@ -40,7 +41,7 @@ public struct RepresentableView: UIViewRepresentable {
 
 public final class RepresentableUIViewController: UIViewController {
     public override func loadView() {
-        self.view = RepresentableUIView(.blue)
+        self.view = RepresentableUIView(.blue, accessibilityUserInputLabels: ["Blue", "Rectangular"])
     }
 }
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,12 +10,48 @@
       }
     },
     {
+      "identity" : "aexml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tadija/AEXML.git",
+      "state" : {
+        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+        "version" : "4.6.1"
+      }
+    },
+    {
+      "identity" : "graphviz",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftDocOrg/GraphViz.git",
+      "state" : {
+        "revision" : "70bebcf4597b9ce33e19816d6bbd4ba9b7bdf038",
+        "version" : "0.2.0"
+      }
+    },
+    {
       "identity" : "ios-snapshot-test-case",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/uber/ios-snapshot-test-case.git",
       "state" : {
         "revision" : "7b10770333a961be6e5a41c9ce04b8c6d3990126",
         "version" : "8.0.0"
+      }
+    },
+    {
+      "identity" : "jsonutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yonaskolb/JSONUtilities.git",
+      "state" : {
+        "revision" : "128d2ffc22467f69569ef8ff971683e2393191a0",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "pathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/PathKit.git",
+      "state" : {
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
       }
     },
     {
@@ -28,12 +64,120 @@
       }
     },
     {
+      "identity" : "rainbow",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Rainbow.git",
+      "state" : {
+        "revision" : "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-cmark.git",
+      "state" : {
+        "revision" : "3bc2f3e25df0cecc5dc269f7ccae65d0f386f06a",
+        "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "swift-format",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-format.git",
+      "state" : {
+        "revision" : "83248b4fa37919f78ffbd4650946759bcc54c2b5",
+        "version" : "509.0.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown.git",
+      "state" : {
+        "revision" : "4aae40bf6fff5286e0e1672329d17824ce16e081",
+        "version" : "0.4.0"
+      }
+    },
+    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
         "revision" : "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
         "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    },
+    {
+      "identity" : "swiftcli",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jakeheis/SwiftCLI.git",
+      "state" : {
+        "revision" : "2e949055d9797c1a6bddcda0e58dada16cc8e970",
+        "version" : "6.0.3"
+      }
+    },
+    {
+      "identity" : "version",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/Version",
+      "state" : {
+        "revision" : "1fe824b80d89201652e7eca7c9252269a1d85e25",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "xcodegen",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yonaskolb/XcodeGen.git",
+      "state" : {
+        "revision" : "87a275fb0852bb231550e66473804de57063c957",
+        "version" : "2.38.0"
+      }
+    },
+    {
+      "identity" : "xcodeproj",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/XcodeProj.git",
+      "state" : {
+        "revision" : "3797181813ee963fe305d939232bc576d23ddbb0",
+        "version" : "8.15.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3036ba9d69cf1fd04d433527bc339dc0dc75433d",
+        "version" : "5.1.3"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,26 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cashapp/AccessibilitySnapshot.git",
       "state" : {
-        "revision" : "482db2fd4251cce237d8106073a53ad5289ce739",
-        "version" : "0.6.0"
-      }
-    },
-    {
-      "identity" : "aexml",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tadija/AEXML.git",
-      "state" : {
-        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
-        "version" : "4.6.1"
-      }
-    },
-    {
-      "identity" : "graphviz",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftDocOrg/GraphViz.git",
-      "state" : {
-        "revision" : "70bebcf4597b9ce33e19816d6bbd4ba9b7bdf038",
-        "version" : "0.2.0"
+        "revision" : "ef2cf6015ad00c791fe3ff60f836b1fcc50f970c",
+        "version" : "0.7.0"
       }
     },
     {
@@ -37,84 +19,12 @@
       }
     },
     {
-      "identity" : "jsonutilities",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/yonaskolb/JSONUtilities.git",
-      "state" : {
-        "revision" : "128d2ffc22467f69569ef8ff971683e2393191a0",
-        "version" : "4.2.0"
-      }
-    },
-    {
-      "identity" : "pathkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kylef/PathKit.git",
-      "state" : {
-        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
-        "version" : "1.0.1"
-      }
-    },
-    {
       "identity" : "playbook-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/playbook-ui/playbook-ios.git",
       "state" : {
-        "revision" : "0e7c312abdb4f7afeaf24369bab114cf475f573c",
-        "version" : "0.3.5"
-      }
-    },
-    {
-      "identity" : "rainbow",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/onevcat/Rainbow.git",
-      "state" : {
-        "revision" : "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
-        "version" : "3.2.0"
-      }
-    },
-    {
-      "identity" : "spectre",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kylef/Spectre.git",
-      "state" : {
-        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
-        "version" : "0.10.1"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-cmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-cmark.git",
-      "state" : {
-        "revision" : "f218e5d7691f78b55bfa39b367763f4612486c35",
-        "version" : "0.3.0"
-      }
-    },
-    {
-      "identity" : "swift-format",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-format.git",
-      "state" : {
-        "revision" : "83248b4fa37919f78ffbd4650946759bcc54c2b5",
-        "version" : "509.0.0"
-      }
-    },
-    {
-      "identity" : "swift-markdown",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-markdown.git",
-      "state" : {
-        "revision" : "e4f95e2dc23097a1a9a1dfdfe3fe3ee44de77378",
-        "version" : "0.3.0"
+        "revision" : "da86a1a533e7ab5b1203908dfbb33aa38b782421",
+        "version" : "0.4.1"
       }
     },
     {
@@ -124,60 +34,6 @@
       "state" : {
         "revision" : "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
         "version" : "1.9.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
-        "version" : "509.1.1"
-      }
-    },
-    {
-      "identity" : "swiftcli",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jakeheis/SwiftCLI.git",
-      "state" : {
-        "revision" : "2e949055d9797c1a6bddcda0e58dada16cc8e970",
-        "version" : "6.0.3"
-      }
-    },
-    {
-      "identity" : "version",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mxcl/Version",
-      "state" : {
-        "revision" : "1fe824b80d89201652e7eca7c9252269a1d85e25",
-        "version" : "2.0.1"
-      }
-    },
-    {
-      "identity" : "xcodegen",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/yonaskolb/XcodeGen.git",
-      "state" : {
-        "revision" : "87a275fb0852bb231550e66473804de57063c957",
-        "version" : "2.38.0"
-      }
-    },
-    {
-      "identity" : "xcodeproj",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/XcodeProj.git",
-      "state" : {
-        "revision" : "3797181813ee963fe305d939232bc576d23ddbb0",
-        "version" : "8.15.0"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
-        "version" : "5.0.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,5 @@ if ProcessInfo.processInfo.environment["PLAYBOOK_DEVELOPMENT"] != nil {
     package.dependencies.append(contentsOf: [
         .package(url: "https://github.com/apple/swift-format.git", exact: "509.0.0"),
         .package(url: "https://github.com/yonaskolb/XcodeGen.git", exact: "2.38.0"),
-        // XcodeGen fails to build with newer version of XcodeProj
-        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.15.0"),
     ])
 }

--- a/Package.swift
+++ b/Package.swift
@@ -15,11 +15,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/playbook-ui/playbook-ios.git",
-            .upToNextMinor(from: "0.3.5")
+            .upToNextMinor(from: "0.4.1")
         ),
         .package(
             url: "https://github.com/cashapp/AccessibilitySnapshot.git",
-            .upToNextMinor(from: "0.6.0")
+            .upToNextMinor(from: "0.7.0")
         ),
     ],
     targets: [

--- a/Sources/AccessibilitySnapshot.swift
+++ b/Sources/AccessibilitySnapshot.swift
@@ -43,7 +43,8 @@ public struct AccessibilitySnapshot: TestTool {
                 let accessibilityView = AccessibilitySnapshotView(
                     containedView: view.superview ?? view,
                     viewRenderingMode: .renderLayerInContext,
-                    activationPointDisplayMode: .always
+                    activationPointDisplayMode: .always,
+                    showUserInputLabels: true
                 )
 
                 // Ignoring the error thrown by the parse function. It will be handled correctly


### PR DESCRIPTION
AccessibilitySnapshot library introduced _breaking_ change in this https://github.com/cashapp/AccessibilitySnapshot/pull/150.

It is a feature to show https://developer.apple.com/documentation/objectivec/nsobject/3197989-accessibilityuserinputlabels for UIKit elements, and may cause diff changes for such UIKit elements

Due to its nature, I opted in by default, as it is make sense to have it in default behavior.

So in case of releasing new version, need to warn about potential differences for such views.

Also bumping in other dependencies and nit updating some docs.

## Evidence

Both are taken after changes to `accessibilityUserInputLabels`.

|Before|After|
|---|---|
|<img width="300" src="https://github.com/user-attachments/assets/faeac521-9ea8-49e4-9e78-6d65f6b4879f">|<img width="300" src="https://github.com/user-attachments/assets/540fb0b2-6edd-430a-81ee-5fb5f952de03">|

